### PR TITLE
Add extra_files property to readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ icon = "icon.png"
 readme = "README.md"
 changelog = "CHANGELOG.md" # optional
 
+ # optional
+extra_files = [
+  "example_gdnative_lib.dll",
+  "example.txt"
+]
+
 # both are optional here, pick what you want
 [project]
 csharp = "./ExampleMod/ExampleMod.csproj"


### PR DESCRIPTION
I didn't see this in the readme so I thought it didn't exist as a feature.